### PR TITLE
SIMP-3415 gdm - acceptance test intermittently fails

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Jul 12 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 7.0.3-0
+- Harden acceptance test
+
 * Thu Jul 06 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 7.0.2-0
 - Update puppet dependency in metadata.json
 

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -1,36 +1,5 @@
 require 'spec_helper_acceptance'
 
-#TODO move to Simp::BeakerHelpers
-require 'timeout'
-
-# Wait up to max_wait_seconds for a command on a host to succeed or fail the test
-# @param [String] host Name of test server on which the command will be executed
-# @param [String] command Command to be executed
-# @param [Float]  max_wait_seconds Maximum number of seconds to wait for the
-#                 message to be found in the log before failing
-# @param [Float]  interval_sec Interval in seconds between log checks
-def wait_for_command_success(
-  host,
-  command,
-  max_wait_seconds = (ENV['SIMPTEST_WAIT_FOR_COMMAND_MAX'] ? ENV['SIMPTEST_WAIT_FOR_COMMAND_MAX'].to_f : 60.0),
-  interval_sec = (ENV['SIMPTEST_COMMAND_CHECK_INTERVAL'] ? ENV['SIMPTEST_COMMAND_CHECK_INTERVAL'].to_f : 1.0)
-)
-  result = nil
-  Timeout::timeout(max_wait_seconds) do
-    while true
-      result = on host, command, :accept_all_exit_codes => true
-      return if result.exit_code == 0
-      sleep(interval_sec)
-    end
-  end
-rescue Timeout::Error => e
-  error_msg = "Failed to successfully execute '#{command}' on #{host} within #{max_wait_seconds} seconds:\n"
-  error_msg += "\texit_code = #{result.exit_code}\n"
-  error_msg += "\tstdout = \"#{result.stdout}\"\n" unless result.stdout.nil? or result.stdout.strip.empty?
-  error_msg += "\tstderr = \"#{result.stderr}\"" unless result.stderr.nil? or result.stderr.strip.empty?
-  fail error_msg
-end
-
 test_name 'simp::gdm class'
 
 describe 'simp::gdm class' do
@@ -63,7 +32,7 @@ describe 'simp::gdm class' do
 
       it 'should be running GDM after reboot' do
         host.reboot
-        wait_for_command_success(host, 'pgrep -u gdm')
+        retry_on(host, 'pgrep -u gdm')
       end
     end
   end

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -1,5 +1,36 @@
 require 'spec_helper_acceptance'
 
+#TODO move to Simp::BeakerHelpers
+require 'timeout'
+
+# Wait up to max_wait_seconds for a command on a host to succeed or fail the test
+# @param [String] host Name of test server on which the command will be executed
+# @param [String] command Command to be executed
+# @param [Float]  max_wait_seconds Maximum number of seconds to wait for the
+#                 message to be found in the log before failing
+# @param [Float]  interval_sec Interval in seconds between log checks
+def wait_for_command_success(
+  host,
+  command,
+  max_wait_seconds = (ENV['SIMPTEST_WAIT_FOR_COMMAND_MAX'] ? ENV['SIMPTEST_WAIT_FOR_COMMAND_MAX'].to_f : 60.0),
+  interval_sec = (ENV['SIMPTEST_COMMAND_CHECK_INTERVAL'] ? ENV['SIMPTEST_COMMAND_CHECK_INTERVAL'].to_f : 1.0)
+)
+  result = nil
+  Timeout::timeout(max_wait_seconds) do
+    while true
+      result = on host, command, :accept_all_exit_codes => true
+      return if result.exit_code == 0
+      sleep(interval_sec)
+    end
+  end
+rescue Timeout::Error => e
+  error_msg = "Failed to successfully execute '#{command}' on #{host} within #{max_wait_seconds} seconds:\n"
+  error_msg += "\texit_code = #{result.exit_code}\n"
+  error_msg += "\tstdout = \"#{result.stdout}\"\n" unless result.stdout.nil? or result.stdout.strip.empty?
+  error_msg += "\tstderr = \"#{result.stderr}\"" unless result.stderr.nil? or result.stderr.strip.empty?
+  fail error_msg
+end
+
 test_name 'simp::gdm class'
 
 describe 'simp::gdm class' do
@@ -32,7 +63,7 @@ describe 'simp::gdm class' do
 
       it 'should be running GDM after reboot' do
         host.reboot
-        on(host, 'pgrep -u gdm')
+        wait_for_command_success(host, 'pgrep -u gdm')
       end
     end
   end


### PR DESCRIPTION
Add wait-or-timeout logic to allow time for gdm daemons to start
after reboot

SIMP-3415 #close