### PR TITLE
(SIMP-3685) pupmod-simp-gdm - Fix metadata.json version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_script:
 bundler_args: --without development system_tests --path .vendor
 before_install: rm Gemfile.lock || true
 script:
+  - bundle exec rake compare_latest_tag
   - bundle exec rake test
 notifications:
   email: false

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-gdm",
-  "version": "7.0.2",
+  "version": "7.0.3",
   "author": "SIMP Team",
   "summary": "manages GDM",
   "license": "Apache-2.0",


### PR DESCRIPTION
Sync up metadata.json and CHANGELOG.  This does not need
to be released, as the change noted in the CHANGELOG is
an improved test.

SIMP-3685 #comment pupmod-simp-gdm