### PR TITLE
(SIMP-4680) Migrate to simp_banners

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -9,6 +9,7 @@ fixtures:
     simplib: https://github.com/simp/pupmod-simp-simplib
     stdlib: https://github.com/simp/puppetlabs-stdlib
     svckill: https://github.com/simp/pupmod-simp-svckill
+    simp_banners: https://github.com/simp/pupmod-simp-simp_banners
 
     # Fixtures needed for acceptance
     gnome: https://github.com/simp/pupmod-simp-gnome

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
-* Sat May 19 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.1.0-0
+* Wed Jun 27 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.1.0-0
+- Moved the default banner selection to `simp_banners`
 - Added support for setting dconf options for GDM
 - Moved package list to data in modules for easy merging and overwriting
 - Added acceptance tests that go through the stages of setting up both GDM and

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -47,18 +47,10 @@ gdm::settings:
     Enable: false
 
 gdm::dconf_hash:
-  gdm:
-    org/gnome/login-screen:
-      # Removes Shutdown From Login Screen
-      disable-restart-buttons:
-        value: true
-      # Do not show the list of available users at login screen
-      disable-user-list:
-        value: true
-      # Enables banner
-      banner-message-enable:
-        value: true
-      # The banner text
-      # This item should be set to a string with an escaped \n in place of newlines, wrapped in single quotes
-      banner-message-text:
-        value: '''--------------------------------- ATTENTION ----------------------------------\n\n                         THIS IS A RESTRICTED COMPUTER SYSTEM\n\nThis computer system, and all related equipment, networks, and\nnetwork devices are provided for authorised use only.  All\nsystems controlled by this organisation will be monitored for\nall lawful purposes.  Monitoring includes the totality of the\noperating system and connected networks.  No events on this\nsystem are excluded from record and there are no exclusions\nfrom this policy.\n\nUse of this system constitutes consent to full monitoring of\nyour activities for use by the authorised monitoring organisation.\nUnauthorised use of this system, including uninvited connections,\nmay subject you to criminal prosecution.\n\nThe data collected from this system may be used for any purpose by\nthe collecting organisation.  If you do not agree to this\nmonitoring, discontinue use of the system IMMEDIATELY.\n\n                         THIS IS A RESTRICTED COMPUTER SYSTEM\n\n--------------------------------- ATTENTION ----------------------------------'''
+  org/gnome/login-screen:
+    # Removes Shutdown From Login Screen
+    disable-restart-buttons:
+      value: true
+    # Do not show the list of available users at login screen
+    disable-user-list:
+      value: true

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -61,6 +61,6 @@ class gdm::config {
 
   dconf::settings { 'GDM Dconf Settings':
     profile       => 'gdm',
-    settings_hash => deep_merge($gdm::dconf_hash, $_banner_settings)
+    settings_hash => deep_merge($_banner_settings, $gdm::dconf_hash)
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,9 +31,7 @@
 # @param banner
 #   Enable a login screen banner
 #
-#   * NOTE: This will *not* take precedence over banner settings set in
-#     `dconf_hash`. If you want to set them there, then you should disable this
-#     setting.
+#   * NOTE: any banner settings set via `dconf_hash` will take precedence
 #
 # @param simp_banner
 #   The name of a banner from the `simp_banners` module that should be used

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,17 +28,38 @@
 # @param auditd
 #   Enable auditd support for this module via the ``simp-auditd`` module
 #
+# @param banner
+#   Enable a login screen banner
+#
+#   * NOTE: This will *not* take precedence over banner settings set in
+#     `dconf_hash`. If you want to set them there, then you should disable this
+#     setting.
+#
+# @param simp_banner
+#   The name of a banner from the `simp_banners` module that should be used
+#
+#   * Has no effect if `banner` is not set
+#   * Has no effect if `banner_content` is set
+#
+# @param banner_content
+#   The full content of the banner, without alteration
+#
+#   * GDM cannot handle '\n' sequences so any banner will need to have those
+#     replaced with the literal '\n' string.
+#
 # @author https://github.com/simp/pupmod-simp-gdm/graphs/contributors
 #
 class gdm (
-  Hash[String, Dconf::SettingsHash] $dconf_hash,
-  Hash[String[1], Optional[Hash]]   $packages,
-  Hash                              $settings,
-  Simplib::PackageEnsure            $package_ensure = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
-  Boolean                           $include_sec    = true,
-  Boolean                           $auditd         = simplib::lookup('simp_options::auditd', { 'default_value' => false }),
+  Dconf::SettingsHash             $dconf_hash,
+  Hash[String[1], Optional[Hash]] $packages,
+  Hash                            $settings,
+  Simplib::PackageEnsure          $package_ensure = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
+  Boolean                         $include_sec    = true,
+  Boolean                         $auditd         = simplib::lookup('simp_options::auditd', { 'default_value'         => false }),
+  Boolean                         $banner         = true,
+  String[1]                       $simp_banner    = 'simp',
+  Optional[String[1]]             $banner_content = undef
 ) {
-
   simplib::assert_metadata($module_name)
 
   include gdm::install

--- a/metadata.json
+++ b/metadata.json
@@ -15,6 +15,10 @@
   ],
   "dependencies": [
     {
+      "name": "simp/simp_banners",
+      "version_requirement": ">= 0.1.0 < 2.0.0"
+    },
+    {
       "name": "simp/auditd",
       "version_requirement": ">= 7.0.0 < 9.0.0"
     },


### PR DESCRIPTION
Moved the banner information out of the data and into options at the top
level so that the common banners from `simp_banners` could be used.

Also, switched things up so that users can specify a banner directly
from Hiera easily.

All options are overridden by a full `dconf_settings` Hash if present.

SIMP-4737 #close