### PR TITLE
(SIMP-4602) Fix deps typo in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -32,7 +32,7 @@
     },
     {
       "name": "puppetlabs/inifile",
-      "version_requirement": ">= 1.6.0 < 2.0.0"
+      "version_requirement": ">= 1.6.0 < 3.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
This has been testing all along with the newer version of inifile listed in simp-core:master Puppetfile.tracking

SIMP-4602 #comment deps fix for pupmod-simp-gdm