### PR TITLE
(SIMP-10204) Ensure testing with CentOS 8.4

### DIFF
--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -19,7 +19,7 @@ HOSTS:
     roles:
       - client
     platform: el-8-x86_64
-    box: centos/8
+    box: generic/centos8
     hypervisor: <%= hypervisor %>
 CONFIG:
   log_level: verbose

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -9,17 +9,19 @@ HOSTS:
   oel7:
     roles:
       - client
-      # roles migrated from now-removed el6 node(s): 
       - default
       - master
     platform:   el-7-x86_64
-    box:        onyxpoint/oel-7-x86_64
+    box:        generic/oracle7
     hypervisor: <%= hypervisor %>
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
-        gpgkeys:
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
+
+  oel8:
+    roles:
+      - client
+    platform:   el-8-x86_64
+    box:        generic/oracle8
+    hypervisor: <%= hypervisor %>
+
 CONFIG:
   log_level: verbose
   type: aio


### PR DESCRIPTION
- update the EL8 nodes in the acceptance tests
  to run with generic/centos8 to make sure they using
  CentOS 8.4
- add oel 8 box to oel test nodeset and use generic box instead of
  onyxpoint box.

SIMP-10204 #comment update gdm
SIMP-10220 #close