### PR TITLE
Update deps to use puppet/systemd

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -12,9 +12,7 @@ fixtures:
     simplib: https://github.com/simp/pupmod-simp-simplib.git
     stdlib: https://github.com/simp/puppetlabs-stdlib.git
     svckill: https://github.com/simp/pupmod-simp-svckill.git
-    systemd:
-      repo: https://github.com/simp/puppet-systemd.git
-      branch: simp-master
+    systemd: https://github.com/simp/puppet-systemd.git
 
     # For compliance testing
     disa_stig-el7-baseline:

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -12,7 +12,9 @@ fixtures:
     simplib: https://github.com/simp/pupmod-simp-simplib.git
     stdlib: https://github.com/simp/puppetlabs-stdlib.git
     svckill: https://github.com/simp/pupmod-simp-svckill.git
-    systemd: https://github.com/simp/puppet-systemd.git
+    systemd:
+      repo: https://github.com/simp/puppet-systemd.git
+      branch: simp-master
 
     # For compliance testing
     disa_stig-el7-baseline:

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,12 @@
 .idea/
 dist
 /pkg
-/spec/fixtures
+# Read everything in fixtures
+/spec/fixtures/*
+# Un-ignore hieradata
+!/spec/fixtures/hieradata/*
+# Except this one, which is auto-generated
+/spec/fixtures/hieradata/hiera.yaml
 /spec/rp_env
 /.rspec_system
 /.vagrant

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Jun 03 2022 Chris Tessmer <chris.tessmer@onyxpoint.com> - 7.4.0
+- Update from camptocamp/systemd to puppet/systemd
+
 * Tue Jun 15 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 7.3.0
 - Removed support for Puppet 5
 - Ensured support for Puppet 7 in requirements and stdlib

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -38,7 +38,6 @@ class gdm::install {
 
         systemd::dropin_file { "${module_name}_hidepid.conf":
           unit          => 'systemd-logind.service',
-          daemon_reload => 'eager',
           notify        => Exec['gdm_restart_logind'],
           content       => @("SYSTEMD_OVERRIDE")
             [Service]

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -34,7 +34,7 @@ class gdm::install {
       $_proc_gid = $facts.dig('simplib__mountpoints', '/proc', 'options_hash', 'gid')
 
       if $_proc_gid {
-        simplib::assert_optional_dependency($module_name, 'camptocamp/systemd')
+        simplib::assert_optional_dependency($module_name, 'puppet/systemd')
 
         systemd::dropin_file { "${module_name}_hidepid.conf":
           unit          => 'systemd-logind.service',

--- a/metadata.json
+++ b/metadata.json
@@ -39,7 +39,7 @@
     "optional_dependencies": [
       {
         "name": "puppet/systemd",
-        "version_requirement": ">= 3.0.0 < 4.0.0"
+        "version_requirement": ">= 3.10.0 < 4.0.0"
       },
       {
         "name": "simp/pam",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-gdm",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "author": "SIMP Team",
   "summary": "manages GDM",
   "license": "Apache-2.0",
@@ -38,8 +38,8 @@
   "simp": {
     "optional_dependencies": [
       {
-        "name": "camptocamp/systemd",
-        "version_requirement": ">= 2.2.0 < 3.0.0"
+        "name": "puppet/systemd",
+        "version_requirement": ">= 3.0.0 < 4.0.0"
       },
       {
         "name": "simp/pam",

--- a/spec/acceptance/suites/compliance/nodesets/default.yml
+++ b/spec/acceptance/suites/compliance/nodesets/default.yml
@@ -26,7 +26,6 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type:      aio
-  vagrant_memsize: 256
 <% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
   puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
 <% end -%>

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -125,7 +125,6 @@ describe 'gdm' do
           end
           it { is_expected.to create_systemd__dropin_file('gdm_hidepid.conf').with({
             :unit => "systemd-logind.service",
-            :daemon_reload => 'eager',
             :content => /SupplementaryGroups=231/
             })
           }


### PR DESCRIPTION
This patch updates from camptocamp/systemd 2.x to puppet/systemd 3.x

This bump is driven by simp/simp-core#829