### PR TITLE
[puppetsync] Support simp-iptables 7.x

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Sep 13 2024 Steven Pritchard <steve@sicura.us> - 7.10.0
+- [puppetsync] Update module dependencies to support simp-iptables 7.x
+
 * Wed Feb 07 2024 Mike Riddle <mike@sicura.us> - 7.9.0
 - [puppetsync] Update metadata upper bounds for puppet-nsswitch, puppet-gitlab, puppet-snmp, simp-pam, and simp-useradd
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-gdm",
-  "version": "7.9.0",
+  "version": "7.10.0",
   "author": "SIMP Team",
   "summary": "manages GDM",
   "license": "Apache-2.0",
@@ -39,7 +39,7 @@
     "optional_dependencies": [
       {
         "name": "puppet/systemd",
-        "version_requirement": ">= 4.0.2 < 7.0.0"
+        "version_requirement": ">= 4.0.2 < 8.0.0"
       },
       {
         "name": "simp/pam",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -100,7 +100,6 @@ RSpec.configure do |c|
   c.mock_with :rspec
 
   c.module_path = File.join(fixture_path, 'modules')
-  c.manifest_dir = File.join(fixture_path, 'manifests') if c.respond_to?(:manifest_dir)
 
   c.hiera_config = File.join(fixture_path, 'hieradata', 'hiera.yaml')
 


### PR DESCRIPTION
Update module dependencies to support simp-iptables 7.x.