### PR TITLE
(#135) Added xorg-x11-server-common package to the package list

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Jun 30 2026 Mike Riddle <mike@sicura.us>
+- Added xorg-x11-server-common package to the package list to ensure
+  the resource is managed.
+
 * Thu Jun 25 2026 Steven Pritchard <steven.pritchard@gmail.com> - 8.0.0
 - Only install the legacy X11/font packages on the EL releases that still ship
   them. `bitmap-fixed-fonts`, `bitmap-lucida-typewriter-fonts`, and

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Tue Jun 30 2026 Mike Riddle <mike@sicura.us>
+* Tue Jun 30 2026 Mike Riddle <mike@sicura.us> - 8.0.1
 - Added xorg-x11-server-common package to the package list to ensure
   the resource is managed.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 * Tue Jun 30 2026 Mike Riddle <mike@sicura.us> - 8.0.1
-- Added xorg-x11-server-common package to the package list to ensure
-  the resource is managed.
+- Added the `xorg-x11-server-common` package to the package list to ensure
+  the resource is managed. It is only installed on the EL releases that still
+  ship it (EL8 and EL9); the X.Org server was removed in EL10.
+- Added the display manager user to the `/proc` access group when `hidepid` is
+  enabled. The login greeter runs in a session owned by that user and could not
+  read `/proc` under `hidepid`, causing the greeter to fail to start on EL9+.
 
 * Thu Jun 25 2026 Steven Pritchard <steven.pritchard@gmail.com> - 8.0.0
 - Only install the legacy X11/font packages on the EL releases that still ship

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -17,7 +17,6 @@ lookup_options:
 # dropped from newer EL repositories are added back per-release in data/os/.
 gdm::packages:
   gdm: ~
-  xorg-x11-server-common: ~
   xorg-x11-fonts-100dpi: ~
   xorg-x11-fonts-75dpi: ~
   xorg-x11-fonts-ISO8859-1-100dpi: ~

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -17,6 +17,7 @@ lookup_options:
 # dropped from newer EL repositories are added back per-release in data/os/.
 gdm::packages:
   gdm: ~
+  xorg-x11-server-common: ~
   xorg-x11-fonts-100dpi: ~
   xorg-x11-fonts-75dpi: ~
   xorg-x11-fonts-ISO8859-1-100dpi: ~

--- a/data/os/RedHat-8.yaml
+++ b/data/os/RedHat-8.yaml
@@ -7,4 +7,5 @@ gdm::packages:
   xorg-x11-docs: ~
   xorg-x11-drivers: ~
   xorg-x11-server-Xorg: ~
+  xorg-x11-server-common: ~
   xorg-x11-utils: ~

--- a/data/os/RedHat-9.yaml
+++ b/data/os/RedHat-9.yaml
@@ -4,4 +4,5 @@
 gdm::packages:
   xorg-x11-drivers: ~
   xorg-x11-server-Xorg: ~
+  xorg-x11-server-common: ~
   xorg-x11-utils: ~

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -54,6 +54,16 @@ class gdm::install {
           refreshonly => true,
           path        => ['/usr/sbin','/usr/bin']
         }
+
+        # The login greeter runs in a session owned by the display manager
+        # user. When hidepid is enabled, that user must also belong to the
+        # /proc access group, otherwise the greeter cannot read /proc and
+        # fails to start (the greeter session dies immediately on EL9+).
+        user { $gdm::display_mgr_user:
+          groups     => [String($_proc_gid)],
+          membership => 'minimum',
+          require    => Simplib::Install['gdm packages'],
+        }
       }
     }
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -34,7 +34,8 @@ class gdm::install {
     # either numerically (1, 2) or by name ('noaccess', 'invisible').
     $_hidepid = pick($facts.dig('simplib__mountpoints', '/proc', 'options_hash', 'hidepid'), 0)
     if ($_hidepid =~ Integer and $_hidepid > 0) or ($_hidepid in ['noaccess', 'invisible']) {
-      $_proc_gid = $facts.dig('simplib__mountpoints', '/proc', 'options_hash', 'gid')
+      $_proc_gid   = $facts.dig('simplib__mountpoints', '/proc', 'options_hash', 'gid')
+      $_proc_group = $facts.dig('simplib__mountpoints', '/proc', 'options_hash', '_gid__group')
 
       if $_proc_gid {
         simplib::assert_optional_dependency($module_name, 'puppet/systemd')
@@ -59,10 +60,15 @@ class gdm::install {
         # user. When hidepid is enabled, that user must also belong to the
         # /proc access group, otherwise the greeter cannot read /proc and
         # fails to start (the greeter session dies immediately on EL9+).
-        user { $gdm::display_mgr_user:
-          groups     => [String($_proc_gid)],
-          membership => 'minimum',
-          require    => Simplib::Install['gdm packages'],
+        #
+        # The group name only resolves once the group itself exists, so this
+        # converges on a subsequent run, like the rest of the hidepid setup.
+        if $_proc_group {
+          user { $gdm::display_mgr_user:
+            groups     => [$_proc_group],
+            membership => 'minimum',
+            require    => Simplib::Install['gdm packages'],
+          }
         }
       }
     }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-gdm",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "author": "SIMP Team",
   "summary": "manages GDM",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -152,6 +152,15 @@ describe 'gdm' do
                 content: %r{SupplementaryGroups=231},
               )
             }
+
+            # The greeter session runs as the display manager user, so that
+            # user must also be a member of the /proc access group.
+            it {
+              is_expected.to contain_user('gdm').with(
+                groups: ['231'],
+                membership: 'minimum',
+              )
+            }
           end
         end
 
@@ -173,6 +182,7 @@ describe 'gdm' do
             end
 
             it { is_expected.not_to create_systemd__dropin_file('gdm_hidepid.conf') }
+            it { is_expected.not_to contain_user('gdm') }
           end
         end
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -157,7 +157,7 @@ describe 'gdm' do
             # user must also be a member of the /proc access group.
             it {
               is_expected.to contain_user('gdm').with(
-                groups: ['231'],
+                groups: ['proc_access'],
                 membership: 'minimum',
               )
             }


### PR DESCRIPTION
This should ensure that the package is in the catalog so it can be protected from removal by automated remediation.