### PR TITLE
(#139) Made the dconf db name and key/value separator configurable

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,16 @@
+* Wed Jul 01 2026 Mike Riddle <mike@sicura.us> - 8.1.0
+- Added the `gdm::dconf_db` parameter to make the `dconf` database that GDM
+  settings are written to configurable. It defaults to `gdm` to preserve the
+  module's historical behavior. Setting it to a database that common scanners
+  inspect (such as `local`, `site`, or `distro`) aids DISA STIG remediation;
+  the GDM profile is updated to source the selected database automatically so
+  the login screen continues to inherit the settings.
+- Added the `gdm::key_val_separator` parameter to make the separator used for
+  settings written to `/etc/gdm/custom.conf` configurable. It defaults to
+  ` = ` to preserve the historical output of the `puppetlabs/inifile` module.
+  Setting it to `=` (no surrounding whitespace) satisfies strict scanner
+  checks such as the DISA STIG OVAL check for `AutomaticLoginEnable`.
+
 * Tue Jun 30 2026 Mike Riddle <mike@sicura.us> - 8.0.2
 - Including the `tuned` class to ensure the tuned package is
   protected from automated remediation when the `gdm` class is

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,9 +7,10 @@ class gdm::config {
   $gdm::settings.each |Gdm::ConfSection $section, NotUndef $section_settings| {
     $section_settings.each |String $key, $value| {
       gdm::set { "GDM [${section}] ${key}:${value}":
-        section => $section,
-        key     => $key,
-        value   => $value
+        section           => $section,
+        key               => $key,
+        value             => $value,
+        key_val_separator => $gdm::key_val_separator
       }
     }
   }
@@ -27,7 +28,7 @@ class gdm::config {
             'type'  => 'user',
             'order' => 1
           },
-          'gdm'                                   => {
+          $gdm::dconf_db                          => {
             'type' => 'system'
           },
           '/usr/share/gdm/greeter-dconf-defaults' => {
@@ -77,7 +78,7 @@ class gdm::config {
       }
 
       dconf::settings { 'GDM Dconf Settings':
-        profile       => 'gdm',
+        profile       => $gdm::dconf_db,
         settings_hash => deep_merge($_banner_settings, $gdm::dconf_hash)
       }
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,17 @@
 #  @see dconf(5)
 #  @see data/common.yaml
 #
+# @param dconf_db
+#   The ``dconf`` database (under ``/etc/dconf/db``) that this module's GDM
+#   settings are written to and that the GDM profile sources via a
+#   ``system-db`` entry.
+#
+#   * Defaults to ``gdm`` to preserve the module's historical behavior
+#   * Set to a database that common scanners inspect (such as ``local``,
+#     ``site``, or ``distro``) when performing DISA STIG remediation. The GDM
+#     profile is updated to include the selected database automatically so the
+#     login screen continues to inherit these settings.
+#
 # @param packages
 #   A Hash of packages to be installed
 #
@@ -17,6 +28,15 @@
 #     { 'gdm' => { 'ensure' => '1.2.3' } }
 #
 #   @see data/common.yaml
+#
+# @param key_val_separator
+#   The character(s) placed between the key and value for settings written to
+#   `/etc/gdm/custom.conf`.
+#
+#   * Defaults to ` = ` to preserve the historical output of the
+#     `puppetlabs/inifile` module
+#   * Set to `=` (no surrounding whitespace) to satisfy strict scanner checks
+#     such as the DISA STIG OVAL check for `AutomaticLoginEnable`
 #
 # @param settings
 #   A Hash of settings that will be applied to `/etc/gdm/custom.conf`
@@ -75,14 +95,16 @@ class gdm (
   Dconf::SettingsHash             $dconf_hash,
   Hash[String[1], Optional[Hash]] $packages,
   Gdm::CustomConf                 $settings,
-  Simplib::PackageEnsure          $package_ensure   = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
-  Boolean                         $include_sec      = true,
-  Boolean                         $auditd           = simplib::lookup('simp_options::auditd', { 'default_value' => false }),
-  Boolean                         $pam              = simplib::lookup('simp_options::pam', { 'default_value' => false }),
-  Boolean                         $banner           = true,
-  String[1]                       $simp_banner      = 'simp',
-  String[1]                       $display_mgr_user = 'gdm',
-  Optional[String[1]]             $banner_content   = undef
+  String[1]                       $dconf_db          = 'gdm',
+  String[1]                       $key_val_separator = ' = ',
+  Simplib::PackageEnsure          $package_ensure    = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
+  Boolean                         $include_sec       = true,
+  Boolean                         $auditd            = simplib::lookup('simp_options::auditd', { 'default_value' => false }),
+  Boolean                         $pam               = simplib::lookup('simp_options::pam', { 'default_value' => false }),
+  Boolean                         $banner            = true,
+  String[1]                       $simp_banner       = 'simp',
+  String[1]                       $display_mgr_user  = 'gdm',
+  Optional[String[1]]             $banner_content    = undef
 ) {
   simplib::assert_metadata($module_name)
 

--- a/manifests/set.pp
+++ b/manifests/set.pp
@@ -18,23 +18,32 @@
 # @param value
 #   The value to which $key should be set under $section
 #
+# @param key_val_separator
+#   The character(s) placed between the key and value in
+#   `/etc/gdm/custom.conf`.
+#
+#   * Defaults to ` = `, matching the historical output of the
+#     `puppetlabs/inifile` module
+#
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 define gdm::set (
   Gdm::ConfSection        $section,
   String                  $key,
-  Variant[Boolean,String] $value
+  Variant[Boolean,String] $value,
+  String[1]               $key_val_separator = ' = '
 ) {
 
   include 'gdm'
 
   ini_setting { "GDM custom config ${name}":
-    ensure  => 'present',
-    path    => '/etc/gdm/custom.conf',
-    section => $section,
-    setting => $key,
-    value   => $value,
-    require => Class['gdm::install'],
-    notify  => Class['gdm::service']
+    ensure            => 'present',
+    path              => '/etc/gdm/custom.conf',
+    section           => $section,
+    setting           => $key,
+    value             => $value,
+    key_val_separator => $key_val_separator,
+    require           => Class['gdm::install'],
+    notify            => Class['gdm::service']
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-gdm",
-  "version": "8.0.2",
+  "version": "8.1.0",
   "author": "SIMP Team",
   "summary": "manages GDM",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -64,6 +64,17 @@ describe 'gdm' do
               expect(dconf_resource[:settings_hash]['org/gnome/login-screen']['banner-message-text']['value']).to include('ATTENTION')
               expect(dconf_resource[:settings_hash]['org/gnome/login-screen']['banner-message-enable']['value']).to be true
             }
+
+            # By default settings land in the `gdm` database and the `gdm`
+            # profile sources it via a `system-db` entry.
+            it { is_expected.to create_dconf__settings('GDM Dconf Settings').with_profile('gdm') }
+            it {
+              is_expected.to create_dconf__profile('gdm').with_entries(
+                'user'                                  => { 'type' => 'user', 'order' => 1 },
+                'gdm'                                   => { 'type' => 'system' },
+                '/usr/share/gdm/greeter-dconf-defaults' => { 'type' => 'file', 'order' => 99 },
+              )
+            }
             it {
               is_expected.to create_gdm__set('GDM [chooser] Multicast:false').with(
                 section: 'chooser',
@@ -123,6 +134,26 @@ describe 'gdm' do
                 expect(dconf_resource[:settings_hash]['org/gnome/login-screen']['banner-message-text']['value']).to match(%r{Department of Commerce}i)
               }
             end
+          end
+
+          context 'with a custom dconf_db' do
+            let(:params) { { dconf_db: 'local' } }
+
+            it { is_expected.to compile.with_all_deps }
+
+            # Settings are written to the configured database so that scanners
+            # inspecting `local.d`/`site.d`/`distro.d` observe them.
+            it { is_expected.to create_dconf__settings('GDM Dconf Settings').with_profile('local') }
+
+            # The GDM profile sources the configured database so the login
+            # screen still inherits the settings.
+            it {
+              is_expected.to create_dconf__profile('gdm').with_entries(
+                'user'                                  => { 'type' => 'user', 'order' => 1 },
+                'local'                                 => { 'type' => 'system' },
+                '/usr/share/gdm/greeter-dconf-defaults' => { 'type' => 'file', 'order' => 99 },
+              )
+            }
           end
         end
 

--- a/spec/defines/set_spec.rb
+++ b/spec/defines/set_spec.rb
@@ -12,15 +12,24 @@ describe 'gdm::set' do
 
         it {
           is_expected.to contain_ini_setting("GDM custom config #{title}").with(
-            'ensure'  => 'present',
-            'path'    => '/etc/gdm/custom.conf',
-            'section' => params[:section],
-            'setting' => params[:key],
-            'value'   => params[:value],
-            'require' => 'Class[Gdm::Install]',
-            'notify'  => 'Class[Gdm::Service]',
+            'ensure'            => 'present',
+            'path'              => '/etc/gdm/custom.conf',
+            'section'           => params[:section],
+            'setting'           => params[:key],
+            'value'             => params[:value],
+            'key_val_separator' => ' = ',
+            'require'           => 'Class[Gdm::Install]',
+            'notify'            => 'Class[Gdm::Service]',
           )
         }
+
+        context 'with a custom key_val_separator' do
+          let(:params) { super().merge(key_val_separator: '=') }
+
+          it {
+            is_expected.to contain_ini_setting("GDM custom config #{title}").with_key_val_separator('=')
+          }
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #139
Fixes #140