### PR TITLE
Add clean-state noop acceptance test

### DIFF
--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -13,6 +13,12 @@ describe 'simp::gdm class' do
 
   hosts.each do |host|
     context "on #{host}" do
+      context 'in noop mode from a clean state' do
+        it 'previews without catalog failures' do
+          apply_manifest_on(host, manifest, catch_failures: true, noop: true)
+        end
+      end
+
       it 'enables epel' do
         enable_epel_on(host)
       end


### PR DESCRIPTION
Adds a `context 'in noop mode from a clean state'` that applies the suite manifest under `--noop` before any real apply, guarding the Sicura console's fresh-node `puppet apply --noop` preview. It reuses the suite's own manifest with no package removal or hieradata, so it previews exactly what the console would show on an as-yet-unmanaged node. Spec-only change; part of the clean-state noop rollout across SIMP modules.